### PR TITLE
general fixes

### DIFF
--- a/web/src/modules/Analytics/Fees/index.js
+++ b/web/src/modules/Analytics/Fees/index.js
@@ -42,7 +42,7 @@ import { ResponsiveContainer, XAxis, YAxis, Tooltip, LineChart, Line } from 'rec
 		const total = props.total_debts;
 		const monthly_payments = props.monthly_payments;
 	
-		return <div className="section table" style={{margin: "20px 0", backgroundColor:"#c2bbbb21", overflowX: "scroll" }}>
+		return <div className="section table no-print" style={{margin: "20px 0", backgroundColor:"#c2bbbb21", overflowX: "scroll" }}>
 				<div className="table row heading">
 					<label style={{ backgroundColor: "#efecec", textAlign:"center" }}> <b> Date     </b></label>
 					<label style={{ backgroundColor: "#bedcff", textAlign:"center" }}> <b> Total    </b> </label>

--- a/web/src/modules/Class/Single/ReportsMenu/index.js
+++ b/web/src/modules/Class/Single/ReportsMenu/index.js
@@ -96,7 +96,9 @@ class ClassReportMenu extends Component {
 					<select {...this.report_former.super_handle(["examFilterText"])}> 
 						<option value="">Select Exam</option>
 						{
-							Array.from(examSet).map(exam => {
+							Array.from(examSet)
+								.sort((a, b) => a.localeCompare(b))
+								.map(exam => {
 								return <option key={exam} value={exam}>{exam}</option>	
 							})
 						}
@@ -107,7 +109,9 @@ class ClassReportMenu extends Component {
 					<select {...this.report_former.super_handle(["subjectFilterText"])}> 
 						<option value="">Select Subject</option>
 						{
-							Array.from(subjects).map(subject => {
+							Array.from(subjects)
+								.sort((a, b) => a.localeCompare(b))
+								.map(subject => {
 								return <option key={subject} value={subject}>{subject}</option>	
 							})
 						}

--- a/web/src/modules/Login/index.js
+++ b/web/src/modules/Login/index.js
@@ -107,7 +107,7 @@ class Login extends Component {
 					</div>
 					<div className="row">
 						<label>Password</label>
-						<input type="password" {...this.former.super_handle(["password"])} placeholder="Password" autoCapitalize="off" onKeyDown={this.handleKeyDown}/>
+						<input type="text" {...this.former.super_handle(["password"])} placeholder="Password" autoCapitalize="off" onKeyDown={this.handleKeyDown}/>
 					</div>
 					<div className="button save" onClick={this.onLogin}>Login</div>
 				</div>

--- a/web/src/modules/Login/index.js
+++ b/web/src/modules/Login/index.js
@@ -32,6 +32,13 @@ class Login extends Component {
 		this.props.login(this.state.login)
 	}
 
+	handleKeyDown = (e) => {
+		// check 'enter' key pressed
+		if(e.keyCode === 13) {
+			this.onLogin()
+		}
+	}
+
 	onSwitchSchool = () => {
 
 		if(this.props.unsyncd_changes > 0) {
@@ -100,7 +107,7 @@ class Login extends Component {
 					</div>
 					<div className="row">
 						<label>Password</label>
-						<input type="text" {...this.former.super_handle(["password"])} placeholder="Password" autoCapitalize="off"/>
+						<input type="password" {...this.former.super_handle(["password"])} placeholder="Password" autoCapitalize="off" onKeyDown={this.handleKeyDown}/>
 					</div>
 					<div className="button save" onClick={this.onLogin}>Login</div>
 				</div>

--- a/web/src/modules/Login/school.js
+++ b/web/src/modules/Login/school.js
@@ -21,8 +21,14 @@ class SchoolLogin extends Component {
 	}
 
 	onLogin = () => {
-		console.log(this.state)
 		this.props.login(this.state.school, this.state.password);
+	}
+
+	handleKeyDown = (e) => {
+		// check 'enter' key pressed
+		if(e.keyCode === 13) {
+			this.onLogin()
+		}
 	}
 
 	componentWillReceiveProps(newProps) {
@@ -67,7 +73,7 @@ class SchoolLogin extends Component {
 					</div>
 					<div className="row">
 						<label>Password</label>
-						<input type="password" {...this.former.super_handle(["password"])} placeholder="Password" />
+						<input type="password" {...this.former.super_handle(["password"])} onKeyDown={this.handleKeyDown} placeholder="Password" />
 					</div>
 					<div className="button save" onClick={this.onLogin}>Login</div>
 				</div>

--- a/web/src/modules/Marks/SingleExam/index.js
+++ b/web/src/modules/Marks/SingleExam/index.js
@@ -333,6 +333,7 @@ class SingleExam extends Component {
 						// 	.filter(([id, student]) => student.section_id === this.section_id())
 						Object.keys(this.state.exam.student_marks || {})
 							.map(xid => this.props.students[xid])
+							.sort((a, b) => (a.RollNumber !== undefined && b.RollNumber !== undefined) ? (parseFloat(a.RollNumber) - parseFloat(b.RollNumber)) : -1 )
 							.map(student => (
 								<div className="section" key={student.id}>
 									

--- a/web/src/modules/Marks/SingleExam/index.js
+++ b/web/src/modules/Marks/SingleExam/index.js
@@ -366,6 +366,7 @@ class SingleExam extends Component {
 											<option value="Fail">Fail</option>
 											<option value="Better">Better</option>
 											<option value="Shown Improvement">Shown Improvement</option>
+											<option value="Absent"> Absent</option>
 										</select>
 									</div>
 							</div>

--- a/web/src/modules/Student/Single/Create/index.tsx
+++ b/web/src/modules/Student/Single/Create/index.tsx
@@ -777,7 +777,7 @@ class SingleStudent extends Component<propTypes, S> {
 						<div className="button green" style={{ width: "initial", marginLeft:"auto" }} onClick={this.addTag}>+</div>
 					</div>}
 
-					{!prospective && Object.keys(this.state.profile.certificates).length > 0 && <div className="divider"> Certificates </div>}
+					{!prospective && Object.keys(this.state.profile.certificates || {}).length > 0 && <div className="divider"> Certificates </div>}
 					{!prospective && <div>
 						{
 							Object.entries(this.state.profile.certificates || {})

--- a/web/src/modules/Student/Single/Create/index.tsx
+++ b/web/src/modules/Student/Single/Create/index.tsx
@@ -92,6 +92,7 @@ interface S {
 	edit: {
 		[id: string]: boolean
 	}
+	show_hide_fee: boolean
 }
 
 interface RouteInfo {
@@ -126,7 +127,8 @@ class SingleStudent extends Component<propTypes, S> {
 				text: "Saved!"
 			},
 			new_tag: "",
-			edit: {}
+			edit: {},
+			show_hide_fee: true
 		}
 
 		this.former = new Former(this, ["profile"])
@@ -775,7 +777,7 @@ class SingleStudent extends Component<propTypes, S> {
 						<div className="button green" style={{ width: "initial", marginLeft:"auto" }} onClick={this.addTag}>+</div>
 					</div>}
 
-					{!prospective && <div className="divider"> Certificates </div>}
+					{!prospective && Object.keys(this.state.profile.certificates).length > 0 && <div className="divider"> Certificates </div>}
 					{!prospective && <div>
 						{
 							Object.entries(this.state.profile.certificates || {})
@@ -787,9 +789,15 @@ class SingleStudent extends Component<propTypes, S> {
 								})
 						}
 					</div>}
+					
+					<div className="no-print row">
+						<div className="button grey" onClick={ () => this.setState({show_hide_fee: !this.state.show_hide_fee})}>
+							{this.state.show_hide_fee ? "Hide" : "Show"} Payments Section
+						</div>
+					</div>
 
-					{(admin || this.props.permissions.fee.teacher) && !prospective ? <div className="divider">Payment</div> : false }
-					{(admin || this.props.permissions.fee.teacher) && !prospective ?
+					{this.state.show_hide_fee && (admin || this.props.permissions.fee.teacher) && !prospective ? <div className="divider">Payment</div> : false }
+					{this.state.show_hide_fee && (admin || this.props.permissions.fee.teacher) && !prospective ?
 						Object.entries(this.state.profile.fees).map(([id, fee]) => {
 							const editable = this.state.edit[id] || this.isNew()
 
@@ -841,7 +849,7 @@ class SingleStudent extends Component<propTypes, S> {
 							</div>
 						})
 					: false }
-					{ admin && !prospective ? <div className="button green" onClick={this.addFee}>Add Additional Fee or Scholarship</div> : false }
+					{ this.state.show_hide_fee && admin && !prospective ? <div className="button green" onClick={this.addFee}>Add Additional Fee or Scholarship</div> : false }
 					{ !admin ? false : <div className="save-delete">
 						{!this.isNew()? <div className="button red" onClick={this.onDelete}>Delete</div> : false}
 						<div className="button blue" onClick={this.onSave}>Save</div>

--- a/web/src/modules/Student/Single/Marks/index.js
+++ b/web/src/modules/Student/Single/Marks/index.js
@@ -77,7 +77,9 @@ class StudentMarksContainer extends Component {
 							<select {...this.former.super_handle(["examFilterText"])}> 
 								<option value="">Select Exam</option>
 								{
-									Array.from(examSet).map(exam => {
+									Array.from(examSet)
+										.sort((a, b) => a.localeCompare(b))
+										.map(exam => {
 										return <option key={exam} value={exam}>{exam}</option>	
 									})
 								}
@@ -89,7 +91,9 @@ class StudentMarksContainer extends Component {
 							<select {...this.former.super_handle(["subjectFilterText"])}> 
 								<option value="">Select Subject</option>
 								{
-									Array.from(subjectSet).map(subject => {
+									Array.from(subjectSet)
+										.sort((a, b) => a.localeCompare(b))
+										.map(subject => {
 										return <option key={subject} value={subject}>{subject}</option>	
 									})
 								}
@@ -236,7 +240,7 @@ export const StudentMarks = ({student, exams, settings, startDate=0, endDate=mom
 				[...Object.keys(student.exams || {})
 					.map(exam_id => exams[exam_id])
 					.filter(exam => moment(exam.date).isBetween(start, end) && getReportFilterCondition(examFilter, exam.name, subjectFilter, exam.subject ))
-					.sort((a, b) => a.date - b.date)
+					.sort((a, b) => examFilter === "" ? (a.date - b.date) : a.subject.localeCompare(b.subject))
 					.map((exam, i) => <div className="table row" key={exam.id}>
 							<div>{ dateOrSerial === "Date" ? moment(exam.date).format("MM/DD") : i + 1 }</div>
 							<div>{exam.subject}</div>


### PR DESCRIPTION
Here's what this PR contains:
`Current Sprint Tasks`
- [x] add no-print to fees analytics
- [x] add 'absent' to exams remarks
- [x] sort subjects on the result card
- [x] sort students by roll no. to create exam 
`Previous Sprint Testing Issues` 
- [x] add check to avoid display `DEFAULT` as section name or result card
- [x] fix sort issue for analytics (student attendance)
`From Prev. Feedback`
- [x] login on `Enter key` press
- [x] add show/hide button for payments/fees in the student profile